### PR TITLE
Fix missing manticore_cluster_size on newer nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -684,10 +684,9 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		case k == "qcache_used_bytes":
 			ch <- prometheus.MustNewConstMetric(e.qcache_used_bytes, prometheus.CounterValue, parse(v))
 		case k == fmt.Sprintf("cluster_%s_size", clusterKey):
+			ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))
 		case k == "qcache_hits":
 			ch <- prometheus.MustNewConstMetric(e.qcache_hits, prometheus.CounterValue, parse(v))
-		case k == fmt.Sprintf("cluster_%s_size", cluster):
-			ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))
 		case k == fmt.Sprintf("cluster_%s_status", clusterKey):
 			override_value = cluster_node_statuses[v]
 			ch <- prometheus.MustNewConstMetric(e.cluster_status, prometheus.CounterValue, parse(override_value))


### PR DESCRIPTION
### Motivation
- Newer Manticore nodes present cluster status keys in a normalized lower-case form, and the exporter previously had an empty branch for `cluster_<clusterKey>_size` while relying on a raw `cluster`-based branch that could miss the metric.

### Description
- Emit `manticore_cluster_size` by adding `ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))` in the `case k == fmt.Sprintf("cluster_%s_size", clusterKey)` branch and remove the duplicate branch that matched the raw `cluster` name.

### Testing
- Ran `go test ./...`, which completed successfully (reported `[no test files]`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f51d4fe4c8320ada7a4a7b72ec77c)