### PR TITLE
Handle generic cluster size keys and fix cluster variable usage in metrics collection

### DIFF
--- a/main.go
+++ b/main.go
@@ -684,10 +684,11 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		case k == "qcache_used_bytes":
 			ch <- prometheus.MustNewConstMetric(e.qcache_used_bytes, prometheus.CounterValue, parse(v))
 		case k == fmt.Sprintf("cluster_%s_size", clusterKey):
+			ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))
+		case strings.HasPrefix(k, "cluster_") && strings.HasSuffix(k, "_size"):
+			ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))
 		case k == "qcache_hits":
 			ch <- prometheus.MustNewConstMetric(e.qcache_hits, prometheus.CounterValue, parse(v))
-		case k == fmt.Sprintf("cluster_%s_size", cluster):
-			ch <- prometheus.MustNewConstMetric(e.cluster_size, prometheus.CounterValue, parse(v))
 		case k == fmt.Sprintf("cluster_%s_status", clusterKey):
 			override_value = cluster_node_statuses[v]
 			ch <- prometheus.MustNewConstMetric(e.cluster_status, prometheus.CounterValue, parse(override_value))


### PR DESCRIPTION
### Motivation

- Ensure cluster size metrics are captured reliably for different cluster key formats and avoid referencing an undefined `cluster` variable.

### Description

- Add a specific case for `fmt.Sprintf("cluster_%s_size", clusterKey)` to emit the `cluster_size` metric using `clusterKey`.
- Add a generic matcher `strings.HasPrefix(k, "cluster_") && strings.HasSuffix(k, "_size")` to capture any `cluster_*_size` keys and emit the `cluster_size` metric.
- Remove the previous case that referenced `cluster` (which caused incorrect/undefined usage) to prevent missing metrics or compilation/runtime issues.

### Testing

- Ran `go build` and the project compiled successfully.
- Ran `go test ./...` and all existing unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699f51d4fe4c8320ada7a4a7b72ec77c)